### PR TITLE
feature(BLAZ-22460): Replaced Blazored toast with Syncfusion toast component

### DIFF
--- a/BlazorWasmGraphQL/Client/BlazorWasmGraphQL.Client.csproj
+++ b/BlazorWasmGraphQL/Client/BlazorWasmGraphQL.Client.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.2.0" />
-    <PackageReference Include="Blazored.Toast" Version="3.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.2" PrivateAssets="all" />
@@ -17,6 +16,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.6.1" />
     <PackageReference Include="StrawberryShake.Transport.Http" Version="12.6.1" />
+    <PackageReference Include="Syncfusion.Blazor.Notifications" Version="20.1.0.56" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorWasmGraphQL/Client/BlazorWasmGraphQL.Client.csproj
+++ b/BlazorWasmGraphQL/Client/BlazorWasmGraphQL.Client.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.6.1" />
     <PackageReference Include="StrawberryShake.Transport.Http" Version="12.6.1" />
     <PackageReference Include="Syncfusion.Blazor.Notifications" Version="20.1.0.56" />
+    <PackageReference Include="Syncfusion.Blazor.Themes" Version="20.1.0.56" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorWasmGraphQL/Client/Pages/AddToWatchlist.razor.cs
+++ b/BlazorWasmGraphQL/Client/Pages/AddToWatchlist.razor.cs
@@ -1,4 +1,4 @@
-﻿using Blazored.Toast.Services;
+﻿using Syncfusion.Blazor.Notifications;
 using BlazorWasmGraphQL.Client.GraphQLAPIClient;
 using BlazorWasmGraphQL.Client.Shared;
 using BlazorWasmGraphQL.Server.Models;
@@ -13,8 +13,7 @@ namespace BlazorWasmGraphQL.Client.Pages
         [Inject]
         AppStateContainer AppStateContainer { get; set; } = default!;
 
-        [Inject]
-        IToastService ToastService { get; set; } = default!;
+        public static SfToast ToastObj;
 
         [Inject]
         MovieClient MovieClient { get; set; } = default!;
@@ -31,6 +30,13 @@ namespace BlazorWasmGraphQL.Client.Pages
         List<Movie> userWatchlist = new();
         protected bool toggle;
         protected string buttonText = string.Empty;
+
+        public static List<ToastModel> Toast = new List<ToastModel>
+        {
+            new ToastModel{  Title = "SUCCESS", Content="Movie added to your Watchlist", CssClass="e-toast-success", Timeout=3000, ShowCloseButton=true},
+            new ToastModel{ Title = "INFO", Content="Movie removed from your Watchlist", CssClass="e-toast-info", Timeout=3000, ShowCloseButton=true},
+            new ToastModel{  Title = "SUCCESS", Content="Movie data is deleted successfully", CssClass="e-toast-success", Timeout=3000, ShowCloseButton=true}
+        };
 
         int UserId { get; set; }
 
@@ -108,11 +114,11 @@ namespace BlazorWasmGraphQL.Client.Pages
 
                 if (toggle)
                 {
-                    ToastService.ShowSuccess("Movie added to your Watchlist");
+                    ToastObj.Show(Toast[0]);
                 }
                 else
                 {
-                    ToastService.ShowInfo("Movie removed from your Watchlist");
+                    ToastObj.Show(Toast[1]);
                 }
 
                 await WatchListClick.InvokeAsync();

--- a/BlazorWasmGraphQL/Client/Pages/ManageMovies.razor.cs
+++ b/BlazorWasmGraphQL/Client/Pages/ManageMovies.razor.cs
@@ -1,5 +1,4 @@
-﻿using Blazored.Toast.Services;
-using BlazorWasmGraphQL.Client.GraphQLAPIClient;
+﻿using BlazorWasmGraphQL.Client.GraphQLAPIClient;
 using BlazorWasmGraphQL.Server.Models;
 using BlazorWasmGraphQL.Shared.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -18,9 +17,6 @@ namespace BlazorWasmGraphQL.Client.Pages
 
         [Inject]
         public NavigationManager NavigationManager { get; set; } = default!;
-
-        [Inject]
-        IToastService ToastService { get; set; } = default!;
 
         [CascadingParameter]
         public Task<AuthenticationState> AuthenticationState { get; set; } = default!;
@@ -71,7 +67,7 @@ namespace BlazorWasmGraphQL.Client.Pages
             if (response.Data is not null)
             {
                 await GetMovieList();
-                ToastService.ShowSuccess("Movie data is deleted successfully");
+                AddToWatchlistBase.ToastObj.Show(AddToWatchlistBase.Toast[2]);
             }
         }
     }

--- a/BlazorWasmGraphQL/Client/Program.cs
+++ b/BlazorWasmGraphQL/Client/Program.cs
@@ -1,5 +1,4 @@
 using Blazored.LocalStorage;
-using Blazored.Toast;
 using BlazorWasmGraphQL.Client;
 using BlazorWasmGraphQL.Client.Shared;
 using BlazorWasmGraphQL.Shared.Models;
@@ -7,6 +6,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using System.Net.Http.Headers;
+using Syncfusion.Blazor;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -20,6 +20,8 @@ builder.Services.AddAuthorizationCore(config =>
 });
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+builder.Services.AddSyncfusionBlazor(options => { options.IgnoreScriptIsolation = true; });
 
 string graphQLServerPath = builder.HostEnvironment.BaseAddress + "graphql";
 
@@ -40,7 +42,6 @@ builder.Services.AddScoped<CustomAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(provider => provider.GetRequiredService<CustomAuthStateProvider>());
 
 builder.Services.AddScoped<AppStateContainer>();
-builder.Services.AddBlazoredToast();
 builder.Services.AddBlazoredLocalStorage();
 
 await builder.Build().RunAsync();

--- a/BlazorWasmGraphQL/Client/Shared/MainLayout.razor
+++ b/BlazorWasmGraphQL/Client/Shared/MainLayout.razor
@@ -1,9 +1,9 @@
 ﻿@inherits LayoutComponentBase
-@using Blazored.Toast.Configuration
+@using BlazorWasmGraphQL.Client.Pages
 
-<BlazoredToasts Position="ToastPosition.BottomCenter"
-                Timeout="3"
-                SuccessClass="success-toast-override" />
+<SfToast @ref="AddToWatchlistBase.ToastObj">
+        <ToastPosition X="Center" Y="Bottom"></ToastPosition>
+</SfToast>
 
 <div class="page">
     <div class="main">

--- a/BlazorWasmGraphQL/Client/_Imports.razor
+++ b/BlazorWasmGraphQL/Client/_Imports.razor
@@ -10,5 +10,5 @@
 @using BlazorWasmGraphQL.Client.Shared
 @using BlazorWasmGraphQL.Client.GraphQLAPIClient
 @using Microsoft.AspNetCore.Components.Authorization
-@using Blazored.Toast
-@using Blazored.Toast.Services
+@using Syncfusion.Blazor
+@using Syncfusion.Blazor.Notifications

--- a/BlazorWasmGraphQL/Client/wwwroot/index.html
+++ b/BlazorWasmGraphQL/Client/wwwroot/index.html
@@ -10,7 +10,8 @@
     <link href="css/app.css" rel="stylesheet" />
     <link href="BlazorWasmGraphQL.Client.styles.css" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
-    <link href="_content/Blazored.Toast/blazored-toast.min.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
+    <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js" type="text/javascript"></script>
 </head>
 
 <body>


### PR DESCRIPTION
1. Replaced Blazored toast with syncfusion toast.
2. Used sftoast component in Mainlayout.razor
3. Used the reference(ToastObj) of sftoast component in AddToWatchList.razor.cs
4. Used List<ToastModel> in order to get the attributes of toast. And then whenever the AddToWatchlist component is toggled  it leads to trigger the ToastObj.Show() .